### PR TITLE
Fix Repo URL Redirections

### DIFF
--- a/src/slides/index.md
+++ b/src/slides/index.md
@@ -4,8 +4,8 @@
 
 <div class="btn btn-warning mt-3 ">raybo.org/slides_practicalactions</div>
 <a href="https://github.com/LinkedInLearning/github-practical-actions-4412872" style="color:white; font-size: .7em; margin-top:10px;">github.com/LinkedInLearning/github-practical-actions-4412872</a>
-<a href="github.com/planetoftheweb/podcast-test" style="color:white; font-size: .7em;">github.com/planetoftheweb/podcast-test</a>
-<a href="github.com/planetoftheweb/podcast-generator" style="color:white; font-size: .7em;">github.com/planetoftheweb/podcast-generator</a>
+<a href="https://github.com/planetoftheweb/podcast-test" style="color:white; font-size: .7em;">github.com/planetoftheweb/podcast-test</a>
+<a href="https://github.com/planetoftheweb/podcast-generator" style="color:white; font-size: .7em;">github.com/planetoftheweb/podcast-generator</a>
 
 <p class="small mt-5">
   <span class="badge bg-dark me-1 ms-2">t</span> toolbar


### PR DESCRIPTION
Currently, clicking on the last two repo links on the homepage redirect to relative paths.
<img width="1227" alt="Screenshot 2024-09-09 at 2 31 10 PM" src="https://github.com/user-attachments/assets/f69faf02-9eb5-49b9-a9bf-7035c708fee5">

Fix: Use absolute links instead of relative links